### PR TITLE
ignore Errno::ESRCH when killed a child process

### DIFF
--- a/lib/parallel_server/prefork.rb
+++ b/lib/parallel_server/prefork.rb
@@ -282,9 +282,9 @@ module ParallelServer
       now = Time.now
       @child_status.each do |r, st|
         if now > st[:time] + @watchdog_timer + 60
-          Process.kill 'KILL', @from_child[r]
+          Process.kill 'KILL', @from_child[r] rescue nil
         elsif now > st[:time] + @watchdog_timer && ! st[:signal_sent]
-          Process.kill @watchdog_signal, @from_child[r]
+          Process.kill @watchdog_signal, @from_child[r] rescue nil
           st[:signal_sent] = true
         end
       end


### PR DESCRIPTION
`watchdog_timer` の値を超えたプロセスを消す時に `Errno::ESRCH` が発生することがありました。

```
.../parallel_server-0.1.6/lib/parallel_server/prefork.rb:285:in `kill': No such process (Errno::ESRCH)
        from .../parallel_server-0.1.6/lib/parallel_server/prefork.rb:285:in `block in kill_frozen_children'
        from .../parallel_server-0.1.6/lib/parallel_server/prefork.rb:283:in `each'
        from .../parallel_server-0.1.6/lib/parallel_server/prefork.rb:283:in `kill_frozen_children'
        from .../parallel_server-0.1.6/lib/parallel_server/prefork.rb:247:in `watch_children'
        from .../parallel_server-0.1.6/lib/parallel_server/prefork.rb:69:in `start'
        ...
```

プロセスが削除済みであれば問題無いと思うので `Errno::ESRCH` は無視するようにしてみました。