### PR TITLE
fix `uninitialize constant`

### DIFF
--- a/lib/parallel_server/prefork.rb
+++ b/lib/parallel_server/prefork.rb
@@ -1,5 +1,6 @@
 require 'socket'
 require 'thread'
+require 'timeout'
 
 module ParallelServer
   class Prefork


### PR DESCRIPTION
終了時に以下のようなエラーが出ていたので、Timeout を使うのをやめるのと、ensure で Thread を生成しないようにしてみました。

```
#<Thread:0x0000560c9f182868@test.rb:7 aborting> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	2: from test.rb:8:in `block in <main>'
	1: from /home/rororo/github/parallel_server/lib/parallel_server/prefork.rb:76:in `start'
/home/rororo/github/parallel_server/lib/parallel_server/prefork.rb:76:in `ensure in start': uninitialized constant ParallelServer::Prefork::Timeout (NameError)
	4: from test.rb:8:in `block in <main>'
	3: from /home/rororo/github/parallel_server/lib/parallel_server/prefork.rb:76:in `start'
	2: from /home/rororo/github/parallel_server/lib/parallel_server/prefork.rb:76:in `ensure in start'
	1: from /home/rororo/github/parallel_server/lib/parallel_server/prefork.rb:76:in `rescue in ensure in start'
/home/rororo/github/parallel_server/lib/parallel_server/prefork.rb:76:in `new': can't alloc thread (ThreadError)
```
再現コード:

```ruby
require 'parallel_server/prefork'

opts = {
  max_idle: 100
}
pl = ParallelServer::Prefork.new(12345, opts)
Thread.new do
  pl.start do |sock, _addr|
    sock.puts 'Who are you?'
    name = sock.gets
    sock.puts "Hello, #{name}"
  end
end

threads = []
thr1 = Thread.new do
  c = Socket.tcp('localhost', 12345)
  puts c.gets
  sleep 1
  c.puts 'alice'
  puts c.gets
  sleep 1
end
threads.push(thr1)

threads.each(&:join)
pl.stop
```