### PR TITLE
keep child connection when child stop

### DIFF
--- a/lib/parallel_server/prefork.rb
+++ b/lib/parallel_server/prefork.rb
@@ -231,10 +231,6 @@ module ParallelServer
           if st = Conversation.recv(from_child)
             st[:time] = Time.now
             @child_status[from_child].update st
-            if st[:status] == :stop
-              @to_child[from_child].close rescue nil
-              @to_child.delete from_child
-            end
           else
             @from_child.delete from_child
             @to_child[from_child].close rescue nil


### PR DESCRIPTION
max-idle 経過後に既存の接続が残っていても watchdog によって子プロセスが殺されてしまう場合があったので、子プロセスとのパイプを閉じないように変更してみました。

再現コード:
```ruby
require 'parallel_server/prefork'

opts = {
  on_child_start: ->(pid) { puts "S: pid=#{pid}" },
  on_child_exit: ->(pid, st) { puts "E: pid=#{pid}, st=#{st}" },
  min_processes: 1,
  max_processes: 1,
  max_threads: 5,
  max_idle: 1,
  watchdog_timer: 7
}
pl = ParallelServer::Prefork.new(12345, opts)
Thread.new do
  pl.start do |sock, _addr|
    sock.puts 'Who are you?'
    name = sock.gets
    p name
    sock.puts "Hello, #{name}"
  end
end

threads = []
thr1 = Thread.new do
  c = Socket.tcp('localhost', 12345)
  puts c.gets
  sleep 10
  c.puts 'alice'
  p c.gets
  c.puts 'hoge'
end
threads.push(thr1)

threads.each(&:join)
pl.stop
```

変更前の実行結果:
```
$ ruby -I./lib test.rb
S: pid=27756
watch_children: st={:status=>:run, :connections=>{47459677408240=>#<Addrinfo: 127.0.0.1:60626 TCP>}, :time=>2019-07-23 23:35:46 +0900}
Who are you?
watch_children: st={:status=>:stop, :connections=>{47459677408240=>#<Addrinfo: 127.0.0.1:60626 TCP>}, :time=>2019-07-23 23:35:47 +0900}
reload_loop: data=nil
reload_loop end: st=stop, pid=27756
S: pid=27760
reload_loop: timeout
watch_children: st={:time=>2019-07-23 23:35:52 +0900}
watch_children: st={:status=>:stop, :connections=>{}, :time=>2019-07-23 23:35:54 +0900}
E: pid=27756, st=pid 27756 SIGTERM (signal 15)
nil
#<Thread:0x00005654226d3a40@test.rb:23 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	2: from test.rb:29:in `block in <main>'
	1: from test.rb:29:in `puts'
test.rb:29:in `write': Broken pipe (Errno::EPIPE)
reload_loop: data=nil
reload_loop end: st=run, pid=27760
watch_children: st={:status=>:stop, :connections=>{}, :time=>2019-07-23 23:35:56 +0900}
E: pid=27760, st=pid 27760 exit 0
Traceback (most recent call last):
	2: from test.rb:29:in `block in <main>'
	1: from test.rb:29:in `puts'
test.rb:29:in `write': Broken pipe (Errno::EPIPE)
```